### PR TITLE
Remove line breaks title in copyright section

### DIFF
--- a/2016/latex/ismir.sty
+++ b/2016/latex/ismir.sty
@@ -59,6 +59,10 @@
 \newcommand{\figref}[1]{\mbox{Figure~\ref{#1}}}
 \newcommand{\eqnref}[1]{\mbox{Eqn~(\ref{#1})}}
 
+% Remove line breaks
+\newcommand{\removelinebreaks}[1]{%
+  \begingroup\def\\{ }#1\endgroup}
+
 \renewcommand{\sfdefault}{phv}
 \renewcommand{\rmdefault}{ptm}
 \renewcommand{\ttdefault}{pcr}
@@ -169,7 +173,7 @@
 \hskip 1.5cm \copyright \hskip .1cm \authorname.
 Licensed under a Creative Commons Attribution 4.0 International License (CC BY 4.0).
 {\bf Attribution: } \authorname.
-``\@title'',
+``\removelinebreaks{\@title}'',
 \conferenceedition\ International Society for Music Information Retrieval Conference,  \conferenceyear.
 \end{spacing}
 }


### PR DESCRIPTION
In some papers (maybe just mine?) people may put line breaks in the title, so that the formatting works nicely; see e.g. [here](https://github.com/craffel/mir_eval-ismir/blob/master/paper/paper.tex#L32), which results in [this](http://colinraffel.com/publications/ismir2014mir_eval.pdf).  Notice that the title gets formatted like we want, but in the copyright notice, the line break looks extremely bizarre.  This adds a command which removes line breaks, and applies it to `\title` in the copyright section.  As far as I can tell, this has no bad side effects.
