### PR TITLE
Update cite.sty from 4.01 to 5.5, to support hyperlinked references

### DIFF
--- a/2018/latex/cite.sty
+++ b/2018/latex/cite.sty
@@ -1,34 +1,37 @@
 %     C I T E . S T Y
 %
-%     version 4.01  (Nov 2003)
+%     version 5.5  (Feb 2015)
 %
 %     Compressed, sorted lists of on-line or superscript numerical citations.
 %     see also drftcite.sty (And the stub overcite.sty)
 %
-%     Copyright (C) 1989-2003 by Donald Arseneau
-%     These macros may be freely transmitted, reproduced, or modified
+%     Copyright (C) 1989-2015 by Donald Arseneau
+%     These macros may be freely used, transmitted, reproduced, or modified
 %     provided that this notice is left intact.
 %
-%     Instructions follow \endinput.
+%     Instructions in cite.pdf and follow \endinput.
 %  ------------------------------------
 % First, ensure that some catcodes have the expected values
-\edef\citenum{% to restore funny codes
+\edef\citenum{% temporary def to restore funny codes later
   \catcode\string`\string ` \the\catcode\string`\`
   \catcode\string`\string ' \the\catcode\string`\'
+  \catcode\string`\string . \the\catcode\string`\.
   \catcode\string`\string = \the\catcode\string`\=
   \catcode\string`\string _ \the\catcode\string`\_
   \catcode\string`\string : \the\catcode\string`\:}
+% set  codes:
 \catcode\string`\` 12
 \catcode`\' 12
+\catcode`\. 12
 \catcode`\= 12
-\catcode`\_ 8
+\catcode`\_ 8  % This is UNusual
 \catcode`\: 12
 
-%   Handle optional variations:
+%   Prepare for optional variations:
 %   [ verbose, nospace, space, ref, nosort, noadjust, superscript, nomove ],
 %   \citeform,\citeleft,\citeright,\citemid,\citepunct,\citedash
 %
-%   Set defaults:
+%   Set defaults first:
 
 %   [ on the left.  Option [ref] does: [Ref. 12, note]
 \providecommand\citeleft{[}
@@ -37,14 +40,20 @@
 \providecommand\citeright{]}
 
 %   , (comma space) before note
-\providecommand\citemid{,\penalty\@medpenalty\ }
+\providecommand\citemid{,\penalty\citemidpenalty\ }
 
 %   , (comma thin-space) between entries; [nospace] eliminates the space
-\providecommand\citepunct{,\penalty\@m\hskip.13emplus.1emminus.1em}%
+\providecommand\citepunct{,\penalty\citepunctpenalty%
+        \hskip.13emplus.1emminus.1em\relax}%
 
 %   -- (endash) designating range of numbers:
 % (using \hbox avoids easy \exhyphenpenalty breaks)
-\providecommand{\citedash}{\hbox{--}\penalty\@m}
+\providecommand{\citedash}{\hbox{--}\penalty\citepunctpenalty}
+
+% Default line-breaking penalties. Use \mathchardef instead of count registers
+\mathchardef\citeprepenalty=\@highpenalty
+\mathchardef\citemidpenalty=\@medpenalty
+\mathchardef\citepunctpenalty=\@m
 
 %   Each number left as-is:
 \providecommand\citeform{}
@@ -56,11 +65,8 @@
 \providecommand\OverciteFont{\fontsize\sf@size\baselineskip\selectfont}
 
 
-%   Do not repeat warnings.  [verbose] reverses
-\let\oc@verbo\relax
-
-% Default is to move punctuation:
-\def\oc@movep#1{\futurelet\@tempb\@citey}
+%   [verbose] is no-op. Default is to repeat warnings anyway.
+%\let\oc@verbo\relax
 
 %----------------------
 % \citen uses \@nocite to ignore spaces after commas, and write the aux file
@@ -69,89 +75,236 @@
 % compress ranges of numbers and print the list. \citen can be used by itself
 % to give citation numbers without the brackets and other formatting; e.g.,
 % "See also ref.~\citen{junk}."
+%  Make internal version called \@cite@n just in case packages put hooks in
+%  \citen
 %
-\DeclareRobustCommand\citen[1]{%
+\DeclareRobustCommand\citen{\@cite@n}
+\def\@cite@n#1{%
  \begingroup
   \let\@safe@activesfalse\@empty
   \@nocite{#1}% ignores spaces, writes to .aux file, returns #1 in \@no@sparg
   \@tempcntb\m@ne    % \@tempcntb tracks highest number
-  \let\@h@ld\@empty  % nothing held from list yet
-  \let\@citea\@empty % no punctuation preceding first
   \let\@celt\delimiter % an unexpandable, but identifiable, token
   \def\@cite@list{}% % empty list to start
+  \let\@citea\@empty % no punctuation preceding first
   \@for \@citeb:=\@no@sparg\do{\@make@cite@list}% make a sorted list of numbers
   % After sorted citelist is made, execute it to compress citation ranges.
   \@tempcnta\m@ne    % no previous number
+  \mathchardef\@cite@incr\z@ % no previous sequence
+  \let\@h@ld\@empty  % nothing held from list yet
   \let\@celt\@compress@cite \@cite@list % output number list with compression
   \@h@ld % output anything held over
  \endgroup
  \@restore@auxhandle
  }
 
-% For each citation, check if it is defined and if it is a number.
-% if a number: insert it in the sorted \@cite@list
-% otherwise: output it immediately.
+% For each citation, check if it is defined. If so, then extract plain
+% value to \@B@citeB (without hyperlink info). Then, 
+% If it is a pure number, add it to cite list
+% Otherwise, try extracting prefix and suffix characters.
 %
 \def\@make@cite@list{%
- \expandafter\let \expandafter\@B@citeB
-          \csname b@\@citeb\@extra@b@citeb \endcsname
- \ifx\@B@citeB\relax % undefined: output ? and warning
+ \expandafter\ifx\csname b@\@citeb\@extra@b@citeb 
+      \endcsname\relax % undefined: output ? and warning
     \@citea {\bfseries ?}\let\@citea\citepunct \G@refundefinedtrue
     \@warning {Citation `\@citeb' on page \thepage\space undefined}%
-    \oc@verbo \global\@namedef{b@\@citeb\@extra@b@citeb}{?}%
- \else %  defined               % remove previous line to repeat warnings
-    \ifcat _\ifnum\z@<0\@B@citeB _\else A\fi % a positive number, put in list
-       \@addto@cite@list
-    \else % citation is not a number, output immediately
-       \@citea \citeform{\@B@citeB}\let\@citea\citepunct
- \fi\fi}
+ %% always verbose \oc@verbo \global\@namedef{b@\@citeb\@extra@b@citeb}{?}%
+ \else %  defined        
+    \@cite@nonhyper@sanitize
+    \@addto@cite@list
+ \fi}
 
-% Regular definition for adding entry to cite list, with sorting
+\def\@nonhyper@@link [#1]#2#3#4{#4}
+\def\@cite@nonhyper@sanitize{\begingroup
+    \let\hyper@@link\@nonhyper@@link
+    \protected@xdef\@B@citeB{\csname b@\@citeb\@extra@b@citeb \endcsname}%
+  \endgroup}
 
-\def\@addto@cite@list{\@tempcnta\@B@citeB \relax
-   \ifnum \@tempcnta>\@tempcntb % new highest, add to end (efficiently)
-      \edef\@cite@list{\@cite@list \@celt{\@B@citeB}}%
-      \@tempcntb\@tempcnta
-   \else % arbitrary number: insert appropriately
-      \edef\@cite@list{\expandafter\@sort@celt \@cite@list \@gobble @}%
-   \fi}
-%
-% \@sort@celt inserts number (\@tempcnta) into list of \@celt{num} (#1{#2})
-% \@celt must not be expandable; list should end with two vanishing tokens.
-%
-\def\@sort@celt#1#2{\ifx \@celt #1% parameters are \@celt {num}
-   \ifnum #2<\@tempcnta % number goes later in list
-      \@celt{#2}%
-      \expandafter\expandafter\expandafter\@sort@celt % continue
-   \else % number goes here
-      \@celt{\number\@tempcnta}\@celt{#2}% stop comparing
-\fi\fi}
+\def\@cite@out#1{\citeform{\csname #1\endcsname}}
 
-% Check if each number follows previous and can be put in a range
+% Add entry to the list of citations.  This default definition sorts pure
+% numbers as well as numbers with other single-character tags.  There 
+% is presently no other definition than this default, but features may 
+% be added later.
 %
-\def\@compress@cite#1{%  % This is executed for each number
-  \advance\@tempcnta\@ne % Now \@tempcnta is one more than the previous number
-  \ifnum #1=\@tempcnta   % Number follows previous--hold on to it
-     \ifx\@h@ld\@empty   % first pair of successives
-        \expandafter\def\expandafter\@h@ld\expandafter{\@citea 
-           \citeform{#1}}%
-     \else               % compressible list of successives
-        \def\@h@ld{\citedash \citeform{#1}}%
-     \fi
-  \else   %  non-successor -- dump what's held and do this one
-     \@h@ld \@citea \citeform{#1}%
-     \let\@h@ld\@empty
-  \fi \@tempcnta#1\let\@citea\citepunct
+\def\@addto@cite@list{% 
+ \@cite@posnumtest\@B@citeB
+   {\@addnumto@cite@list\@B@citeB}%  a positive number, put in list
+   {\@cite@combo@num}% not a pure positive number, test for combo forms
 }
 
-% Make \cite choose superscript or normal
+% With this \@cite@combo@num we delve into handling of numbers combined
+% with non-numeric tags.  The specific command name \@cite@combo@num can
+% serve as a hook for redefinition, perhaps to give simple non-sorting 
+% for anything not a pure number, or to attempt even more complicated
+% sorting, say dictionary sorting of textual citations.  The following
+% definition leads down the road of sorting mostly-numbers but with 
+% optional single-character prefix and/or suffix. 
+
+\def\@cite@combo@num{\expandafter\@cite@try@combo\@B@citeB\delimiter}
+
+% First of many stages for sorting numbers with prefix/suffix characters.
+% Test for a leading token of category letter or other (appropriate for
+% all combination types).
+%
+\def\@cite@try@combo{%
+  \@if@printable@char{\@cite@try@prefix}{\@cite@gobbledump@now}}
+
+% First token is good, so test for a character prefix before a number.
+% Process first token, either a first digit or a prefix
+%
+\def\@cite@try@prefix#1{% #1 is first character of citation
+  \@cite@posnumtest{#1}% a digit else prefix
+   {\@cite@add@letnumD {\z@}#1}% no prefix character (use zero)
+   {\@cite@add@letnumC {`#1}}% prefix char; use the char code
+}
+
+% Examine character after prefix to ensure it is a number.  First must
+% ensure it is a plain character token
+%
+\def\@cite@add@letnumC#1{\@if@printable@char%
+   {\@cite@add@letnumD{#1}}% continue with prefix (perhaps zero)
+   {\@cite@gobbledump@now}% else abandon fancy processing and output citation
+}
+
+% Save prefix (if any) numerically in \@tempcnta, test next character for being
+% a digit, then collect main number
+%
+\def\@cite@add@letnumD#1#2{% #1 = numeric code for prefix, #2 = next char
+  \@tempcnta=#1\multiply\@tempcnta 16384 %
+  \@cite@posnumtest{#2}% if next char is a digit, continue with number:
+   {\afterassignment\@cite@add@letnumE \advance\@tempcnta #2}%
+   {\@cite@gobbledump@now}% No number so just output citation
+}
+
+% Have collected number.  Now look for a non-number suffix or separator.
+%
+\gdef\@cite@add@letnumE{%
+  \multiply\@tempcnta\@cclvi
+  \@if@printable@char{% a suffix or separator given
+      \@cite@add@letnumF
+    }{% else, maybe nothing remains
+      \ifx\@let@token\delimiter % use number, and remove trailing \delimiter
+        \@citeaddcnta \expandafter\@gobble
+      \else % non-printable char found, so abandon fancy processing
+        \expandafter\@cite@gobbledump@now
+      \fi
+    }}
+
+%  Have everything up to a suffix or separator character.  Check 
+%  following to see which. Three possibilites are (1) nothing =>
+%  a suffix; (2) number => separator-number; (3) other => garbage.
+%
+\def\@cite@add@letnumF#1#2\delimiter{% #1 = suffix/separator #2=rest
+  \advance\@tempcnta`#1\relax
+  \@cite@posnumtest{#2}{\@cite@add@numsepnum{#2}}% handle as num sep num
+    {% else...
+     \ifx\delimiter#2\delimiter % nothing left, so #1 is a suffix
+       \@citeaddcnta
+     \else % some non-number; dump it
+       \@cite@dump@now
+     \fi
+}}
+
+% Handle citation as number separator number.
+% Yes, there is a bug that the list 1.1,1.258,1.515 will be compressed as
+% 1.1-1.515; so sue me.
+
+\def\@cite@add@numsepnum#1{% #1 = last number
+  \ifnum\@tempcnta<262144 % OK numeric range
+    \multiply\@tempcnta 4096
+    \advance\@tempcnta #1 % num,sep,num have maximum numbers:  1023, 255, 4095
+    \@citeaddcnta
+  \else % out of range, treat as raw string
+    \@cite@dump@now
+  \fi}
+
+% This is our bail-out when the citation cannot be processed as
+% [prefix]number[suffix] or number[sep]number: it outputs the citation 
+% immediately (unsorted) and consumes tokens to the \delimiter tag used 
+% as an end-marker
+%
+\def\@cite@gobbledump@now#1\delimiter{\@cite@dump@now}%
+
+\def\@cite@dump@now{%
+  \@citea \@cite@out{b@\@citeb\@extra@b@citeb}\let\@citea\citepunct}
+
+% add an entry to the sorted list, using its sort-number \@tempcnta, and
+% also saving the plain-text value \@B@citeB as well as the csname 
+% b@\@citeb\@extra@b@citeb. (The \@B@citeB is actually not used, unless 
+% somebody extends the definitions.)
+\def\@citeaddcnta{%
+   \ifnum \@tempcnta>\@tempcntb % new highest, add to end (efficiently)
+      \edef\@cite@list{\@cite@list 
+        \@celt{\number\@tempcnta}{\@B@citeB}{b@\@citeb\@extra@b@citeb}}%
+      \@tempcntb\@tempcnta
+   \else % other sortable value: insert appropriately
+      \edef\@cite@list{\expandafter\@sort@celt\@cite@list \@gobble.\@gobble.}%
+   \fi
+  }
+
+% add pure numeric entry to cite list, with sorting
+\def\@addnumto@cite@list#1{%
+   \@tempcnta#1\relax
+   \multiply\@tempcnta\@cclvi
+   \@citeaddcnta}
+
+% \@sort@celt inserts number (\@tempcnta) into list of \@celt{num}{text}{tag} 
+% (#1{#2}{#3}{#4})
+% \@celt must not be expandable, and the arguments must not be fragile. 
+% List should end with four vanishing tokens.
+%
+\def\@sort@celt#1#2#3#4{\ifx \@celt #1% parameters are \@celt{num}{text}{tag}
+   \ifnum #2<\@tempcnta % number goes later in list
+      \@celt{#2}{#3}{#4}%
+      \expandafter\expandafter\expandafter\@sort@celt % continue
+   \else % number goes here
+      \@celt{\number\@tempcnta}{\@B@citeB}{b@\@citeb\@extra@b@citeb}%
+      \@celt{#2}{#3}{#4}% stop comparing
+\fi\fi}
+
+% Check if each number follows previous and can be put in a range. 
+% Since there are suffix characters allowed, there are two kinds of 
+% ranges: ranges of consecutive pure numbers with no (or same) 
+% suffix, or ranges of the same number with consecutive suffix
+% characters.
+%
+\def\@compress@cite#1#2#3{%% This is executed for each number
+  \ifnum\@cite@incr=\z@   % no consecutives pending. Try both types of sequence
+    \advance\@tempcnta\@cclvi % Now \@tempcnta has incremented number
+    \ifnum #1=\@tempcnta    % Start a sequence of consecutive numbers
+       \expandafter\def\expandafter\@h@ld\expandafter{\@citea\@cite@out{#3}}%
+       \mathchardef\@cite@incr=\@cclvi
+    \else % next try increment of suffix
+       \advance\@tempcnta-\@cclv % Now \@tempcnta has incremented suffix
+       \ifnum #1=\@tempcnta      % Start a sequence of suffix increments
+         \expandafter\def\expandafter\@h@ld\expandafter{\@citea\@cite@out{#3}}%
+         \mathchardef\@cite@incr=\@ne
+       \else % it is no type of sequence -- emit number (nothing is held)
+         \@citea \@cite@out{#3}%
+       \fi
+    \fi
+  \else % a sequence is running
+    \advance\@tempcnta\@cite@incr % Now \@tempcnta is next in sequence
+    \ifnum #1=\@tempcnta   % Number follows previous--hold on to it
+       \def\@h@ld{\citedash \@cite@out{#3}}%
+    \else   %  non-successor -- dump what's held and do this one
+       \@h@ld \@citea \@cite@out{#3}%
+       \let\@h@ld\@empty
+       \mathchardef\@cite@incr=\z@
+    \fi
+  \fi
+  \@tempcnta#1\let\@citea\citepunct
+}
+
+% Ordinary on-line \cite command
 
 \DeclareRobustCommand{\cite}{%
   \@ifnextchar[{\@tempswatrue\@citex}{\@tempswafalse\@citex[]}}
 
 % Do \cite command on line.
 %
-\def\@citex[#1]#2{\@cite{\citen{#2}}{#1}}
+\def\@citex[#1]#2{\@cite{\@cite@n{#2}}{#1}}
 
 \def\@cite#1#2{\leavevmode \cite@adjust
   \citeleft{#1\if@tempswa\@safe@activesfalse\citemid{#2}\fi
@@ -165,70 +318,41 @@
 %
 \def\cite@adjust{\begingroup%
   \@tempskipa\lastskip \edef\@tempa{\the\@tempskipa}\unskip
-  \ifnum\lastpenalty=\z@ \penalty\@highpenalty \fi
+  \ifnum\lastpenalty=\z@ \penalty\citeprepenalty \fi
   \ifx\@tempa\@zero@skip \spacefactor1001 \fi % if no space before, set flag
   \ifnum\spacefactor>\@m \ \else \hskip\@tempskipa \fi
   \endgroup}
 
-
 \edef\@zero@skip{\the\z@skip}
-
-%  Superscript cite, with no optional note.  Check for punctuation first.
-%
-\def\@citew#1{\begingroup \leavevmode
-  \@if@fillglue \lastskip \relax \unskip
-  \def\@tempa{\@tempcnta\spacefactor
-     \/% this allows the last word to be hyphenated, and it looks better.
-     \@citess{\citen{#1}}\spacefactor\@tempcnta
-     \endgroup \@restore@auxhandle}%
-  \oc@movep\relax}% check for following punctuation (depending on options)
-
-%  Move trailing punctuation before the citation:
-%
-\def\@citey{\let\@tempc\@tempa
-   % Watch for double periods and suppress them
-   \ifx\@tempb.\ifnum\spacefactor<\@bigSfactor\else
-     \let\@tempb\relax \let\@tempc\oc@movep
-   \fi\fi
-   % Move other punctuation
-   \expandafter\@citepc\CiteMoveChars\delimiter
-   \@tempc}%
-
-\def\@citepc#1{%
-   \ifx\@tempb#1\@empty #1\let\@tempc\oc@movep \fi
-   \ifx\delimiter#1\else \expandafter\@citepc\fi}
-
-%  Replacement for \@cite which defines the formatting normally done
-%  around the citation list.  This uses superscripts with no brackets.
-%  HOWEVER, trailing punctuation has already been moved over.  The
-%  format for cites with note is given by \@cite.  Redefine \@cite and/
-%  or \@citex to get different appearance.  I don't use \textsuperscript
-%  because it is defined BADLY in compatibility mode.
-
-\def\@citess#1{\mbox{$\m@th^{\hbox{\OverciteFont{#1}}}$}}
 
 % \nocite: This is changed to ignore *ALL* spaces and be robust.  The
 % parameter list, with spaces removed, is `returned' in \@no@sparg, which
-% is used by \citen.
+% is used by \@cite@n (\citen).
 %
 \DeclareRobustCommand\nocite[1]{%
  \@bsphack \@nocite{#1}%
  \@for \@citeb:=\@no@sparg\do{\@ifundefined{b@\@citeb\@extra@b@citeb}%
     {\G@refundefinedtrue\@warning{Citation `\@citeb' undefined}%
-    \oc@verbo \global\@namedef{b@\@citeb\@extra@b@citeb}{?}}{}}%
+    %%\oc@verbo \global\@namedef{b@\@citeb\@extra@b@citeb}{?}
+    }{}}%
  \@esphack}
 
 \def\@nocite#1{\begingroup\let\protect\string% normalize active chars
- \xdef\@no@sparg{\expandafter\@ignsp#1 \: }\endgroup% and remove ALL spaces
- \if@filesw \immediate\write\@newciteauxhandle % = \@auxout, except with multibib
+ \xdef\@no@sparg{\expandafter\@cite@ignsp#1,\: ,\:}% remove spaces
+ \if@filesw \immediate\write\@newciteauxhandle % =\@auxout, except with multibib
     {\string\citation {\@no@sparg}}\fi
- }
+ \endgroup}
 
-% for ignoring *ALL* spaces in the input.  This presumes there are no
-% \outer tokens and no \if-\fi constructs in the parameter.  Spaces inside
-% braces are retained.
+% remove spaces before and after commas. One level of braces is also
+% stripped, so an item {a,b} is changed to two a and b.
 %
-\def\@ignsp#1 {\ifx\:#1\@empty\else #1\expandafter\@ignsp\fi}
+\def\@cite@ignsp#1 ,#2{\ifx\:#2\@empty 
+  \expandafter\@cite@ignsp@\romannumeral-`\:\else
+  \expandafter\@cite@ignsp \fi #1,#2}
+\def\@cite@ignsp@#1,#2{#1\ifx\:#2\@empty\expandafter\@gobblethree
+   \else,\expandafter\@cite@ignsp@\fi #2}
+
+\long\def\@gobblethree #1#2#3{}
 
 % \@if@fillglue{glue}{true}{false}
 \begingroup
@@ -241,54 +365,164 @@
  \def\@is@fil@ #1FIL#2\relax#3#4\@nil{#3}
 }
 
+% Test if next token is a char of "printable" categories other or letter or 
+% active.  Syntax:
+%  \@if@printable@char {do if printable}{do if not printable}<char>
+%
+\def\@if@printable@char#1#2{%
+  \def\reserved@a{#1}%
+  \def\reserved@b{#2}%
+  \futurelet\@let@token\@test@print@char
+}
+
+% Note side-effect of redefining \reserved@a and \reserved@b
+\def\@test@print@char{%
+ \ifnum 
+    \ifcat\noexpand\@let@token A1\fi
+    \ifcat\noexpand\@let@token 11\fi
+    \ifcat\noexpand\@let@token \noexpand~1\fi%
+  0>\z@
+    \expandafter\reserved@a \else
+    \expandafter\reserved@b \fi
+}
+
+% Test for a pure positive number: {possible number}{true}{false}
+\def\@cite@posnumtest#1{%
+  \ifcat _\ifnum\z@<0#1_\else A\fi
+    \expandafter\@firstoftwo \else \expandafter\@secondoftwo \fi
+}
+
 \let\nocitecount\relax  % in case \nocitecount was used for drftcite
-
-% For the time being, just prevent gross errors from using hyperref.
-% There are no hyper-links.  (I will need to carry the cite tags through
-% the sorting process, and use \hyper@natlinkstart)
-
-\providecommand\hyper@natlinkstart[1]{}
-\providecommand\hyper@natlinkend{}
-\providecommand\NAT@parse{\@firstofone}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %                     option processing
-
-\DeclareOption{verbose}{\def\oc@verbo#1#2#3#4{}}
-\DeclareOption{nospace}{\def\citepunct{,\penalty\@m}}
-\DeclareOption{space}{\def\citepunct{,\penalty\@highpenalty\ }}
+\def\oc@movep{YY}% default Yes move
+%
+\DeclareOption{verbose}{}% Unused now. Was \def\oc@verbo#1#2#3#4{}
+\DeclareOption{nospace}{\def\citepunct{,\penalty\citepunctpenalty}}
+\DeclareOption{space}{\def\citepunct{,\penalty\citepunctpenalty\ }}
+\DeclareOption{nobreak}{% no line-breaks
+ \mathchardef\citeprepenalty=\@M
+ \mathchardef\citemidpenalty=\@M
+ \mathchardef\citepunctpenalty=\@M
+}
 \DeclareOption{ref}{\def\citeleft{[Ref.\penalty\@M\ }}
-\DeclareOption{nosort}{\def\@addto@cite@list
-   {\edef\@cite@list{\@cite@list \@celt{\@B@citeB}}}}
+%  To disable sorting [nosort], the redefinition depends on whether [nocompress]
+%  was also selected, so just set a flag first.
+\DeclareOption{nosort}{\let\@citeaddcnta\@empty}
 \DeclareOption{sort}{}% default!
-\DeclareOption{nomove}{\def\oc@movep{\@tempa}\let\@citey\oc@movep}
-\DeclareOption{move}{}% default
-\DeclareOption{nocompress}{%
-  \def\@compress@cite#1{%  % This is executed for each number
-     \@h@ld \@citea \hyper@natlinkstart\citeform{#1}\hyper@natlinkend
-     \let\@h@ld\@empty \let\@citea\citepunct}
-}
+%  Likewise set flag for [nocompress]
+\DeclareOption{nocompress}{\let\@compress@cite\@empty}
 \DeclareOption{compress}{}% default
+\DeclareOption{nomove}{\def\oc@movep{no}}% Flag for later definition
+\DeclareOption{move}{\def\oc@movep{YY}}% default
 \DeclareOption{super}{\ExecuteOptions{superscript}}
-\DeclareOption{superscript}{%
-  \DeclareRobustCommand{\cite}{%
-    \@ifnextchar[{\@tempswatrue\@citex}{\@tempswafalse\@citew}}
-}
+\DeclareOption{superscript}{\let\@citess\cite}% Just a flag redefined below
 \DeclareOption{noadjust}{\let\cite@adjust\@empty}% Don't change spaces
 \DeclareOption{adjust}{}% adjust space before [ ]
-\DeclareOption{biblabel}{\def\@biblabel#1{\@citess{#1}\kern-\labelsep\,}}
-\ProvidesPackage{cite}[2003/11/04 \space  v 4.01]
+\DeclareOption{biblabel}{\let\@biblabel\def}% see below
+\ProvidesPackage{cite}[2015/02/27 \space v 5.5]
 \ProcessOptions
 
-\ifx\@citey\oc@movep\else % we are moving punctuation; must ensure sfcodes
-  \mathchardef\@bigSfactor3000
-  \expandafter\def\expandafter\frenchspacing\expandafter{\frenchspacing
-    \mathchardef\@bigSfactor1001
-    \sfcode`\.\@bigSfactor \sfcode`\?\@bigSfactor \sfcode`\!\@bigSfactor }%
-  \ifnum\sfcode`\.=\@m \frenchspacing \fi
+\ifx\@biblabel\def % [biblabel] option 
+  \ifx\@citess\cite % [superscript] option
+    \def\@biblabel#1{\@citess{#1}\kern-\labelsep\,}
+  \else % normal
+    \def\@biblabel#1{\citeleft{#1}\citeright}
+  \fi
 \fi
 
-%  Compatability with chapterbib (see use of \@extra@b@citeb)
+% Process [superscript] option, and [nomove].
+
+\ifx\@citess\cite 
+
+%  Superscript cite, \cite chooses superscript or on-line-with-note
+%
+\DeclareRobustCommand{\cite}{%
+    \@ifnextchar[{\@tempswatrue\@citex}{\@tempswafalse\@citew}}
+
+%  Superscript cite, with no optional note.  Check for punctuation first.
+\def\@citew#1{\begingroup \leavevmode
+  \@if@fillglue \lastskip \relax \unskip
+  \def\@tempa{\@tempcnta\spacefactor
+     \/% this allows the last word to be hyphenated, and it looks better.
+     \@citess{\@cite@n{#1}}\spacefactor\@tempcnta
+     \endgroup \@restore@auxhandle}%
+  \oc@movep\relax}% check for following punctuation (depending on options)
+
+%  \@citess defines the formatting with superscripts and no brackets.
+%  HOWEVER, trailing punctuation has already been moved over.  The
+%  format for cites with note is given by \@cite.  Redefine \@cite and/
+%  or \@citex to get different appearance.  I don't use \textsuperscript
+%  because it is defined BADLY in compatibility mode.
+
+\def\@citess#1{\mbox{$\m@th^{\hbox{\OverciteFont{#1}}}$}}
+
+\if \oc@movep %  Move citation past trailing punctuation; [move] is default
+
+\def\oc@movep#1{\futurelet\@tempb\@citey}
+%
+\def\@citey{\let\@tempc\@tempa
+   % Watch for double periods and suppress them
+   \ifx\@tempb.\ifnum\spacefactor<\sfcode`.\else
+     \@citeundouble
+   \fi\fi
+   % Move other punctuation
+   \expandafter\@citepc\CiteMoveChars\delimiter
+   \@tempc}%
+
+% This is in a separate macro in case the next "character" (token)
+% is \if or \fi, etc.
+\def\@citeundouble{% Suppress doubling of periods
+   \let\@tempb\relax \let\@tempc\oc@movep
+}
+
+\def\@citepc#1{%
+   \ifx\@tempb#1\@empty #1\let\@tempc\oc@movep \fi
+   \ifx\delimiter#1\else \expandafter\@citepc\fi}
+
+%  Set detectable sfcodes when \frenchspacing
+\mathchardef\cite@mi1001 % 
+\g@addto@macro\frenchspacing
+    {\sfcode`\.\cite@mi \sfcode`\?\cite@mi \sfcode`\!\cite@mi }%
+\AtBeginDocument {%
+  \ifnum\sfcode`\.<1002 \frenchspacing  \let\normalsfcodes\frenchspacing \fi
+}% performed after \normalsfcodes defined
+
+\else % [nomove] option:
+
+  \def\oc@movep{\@tempa}
+  \let\@citey\relax
+
+\fi % end of move/nomove options
+%
+\fi %  end [superscript] option processing
+%
+%  make redefinitions to handle [nosort] [nocompress] and their combination
+\ifx\@compress@cite\@empty
+   \ifx\@citeaddcnta\@empty
+      % [nosort,nocompress] -- short-circuit much processing
+      \def\@addto@cite@list{\@cite@dump@now}
+   \else
+      % [sort,nocompress]
+      \def\@compress@cite#1#2#3{%  % This is executed for each number
+        \@h@ld \@citea \@cite@out{#3}%
+        \let\@h@ld\@empty \let\@citea\citepunct
+      }
+   \fi
+\else %  
+   \ifx\@citeaddcnta\@empty % [nosort,compress]
+     %  nosort: always add to end of list, but still calculate
+     %  sort-order number (\@tempcnta) because it may be used for
+     %  collapsing consecutive numbers.
+     \def\@citeaddcnta{%
+       \edef\@cite@list{\@cite@list 
+        \@celt{\number\@tempcnta}{\@B@citeB}{b@\@citeb\@extra@b@citeb}}%
+     }
+   \fi
+\fi
+
+%  Compatability with chapterbib (see use of \@extra@b@citeb above and in chapterbib)
 \@ifundefined{@extra@b@citeb}{\def\@extra@b@citeb{}}{}
 
 %  Compatability with multibib (see use of \@newciteauxhandle) (Yes, this is
@@ -299,19 +533,27 @@
 \AtBeginDocument{\@ifundefined{newcites}{\global\let\@restore@auxhandle\relax}{}}
 \def\@restore@auxhandle{\def\@newciteauxhandle{\@auxout}}
 
+%  compatability with backref: prevent it from redefining \@citex
+%  in the wrong way (ignoring \@citew and \citen.  I install hook in
+%  \@nocite so it applies to \cite, \citen, and \nocite.
+%
+\AtBeginDocument{\@ifundefined{Hy@backout}{}{%
+  \@ifundefined{BRorg@citex}{}{\global\let\@citex\BRorg@citex}%
+  \global\let\BR@citex\@citex
+  \global\let\@citeorg@nocite\@nocite % use my own hook -> into \@nocite
+  \gdef\@nocite#1{\@citeorg@nocite{#1}\Hy@backout{#1}}%
+}}
 
-\@ifundefined{G@refundefinedtrue}{\let\G@refundefinedtrue\relax}{}
-
-\@ifundefined{@safe@activesfalse}{}{}
+%  compatability with babel:  Prevent it from redefining \@citex
+\@ifundefined{@safe@activesfalse}{\let\@safe@activesfalse\relax}{}
 \@ifundefined{bbl@cite@choice}{}{\@ifundefined{org@@citex}{}%
   {\let\org@@citex\@citex}}% Prevent stomping by babel
-
 
 \citenum % execute restore-catcodes
 
 % Aliases:
-\let\citenum\citen
-\let\citeonline\citen
+\def\citenum{\citen}
+\def\citeonline{\citen}
 
 \endinput
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -319,97 +561,46 @@
 
                    CITE.STY
 
-Modify LaTeX's normal citation mechanism to:
+Modify LaTeX's normal citation mechanism for improved handling of numeric
+citations, behaving as follows:
 
-o Put a comma and a small space between each citation number. The option
-  [nospace] removes that space, and the option [space] replaces it with
-  an ordinary inter-word space.
+o Put a comma and a small space between each citation number, allowing 
+  line breaks with penalty.
 
-o Sort citation numbers into ascending order, printing non-numbers before 
-  numbers.  All numbers should be greater than zero.  The [nosort] package 
-  option turns off sorting.
+o Compress lists of three or more consecutive numbers, or similar, to a 
+  range which can be split, with difficulty, after the dash.  
 
-o Compress lists of three or more consecutive numbers to one number range
-  which can be split, with difficulty, after the dash.  All numbers should
-  be greater than zero.  E.g., if you used to get the (nonsense) list 
-  [7,5,6,?,4,9,8,Einstein,6], then this style will give [?,Einstein,4-6,6-9].
-  Compression of ranges is disabled by the [nocompress] package option.
+o Sort citations into ascending order.  
 
-o Allow, but strongly discourage, line breaks within a series of
-  citations.  Each number is separated by a comma and a small space.
-  A break at the beginning of an optional note is discouraged also.
+o Sortable and compressible citations are numeric like [5-8]; or numbers 
+  with prefix and/or suffix characters like [18a-18c,19] or [A2,Q1,Q3-Q5];
+  or two numbers with separator like [1.9-1.12,2.2].
 
-o Put a high-penalty breakpoint before the citation (unless you specifically
-  forbid it with ~ ).  Also, adjust the spacing: if there is no space or if
-  there is extra space due to some punctuation, then change to one inter-word
-  space. E.g.,   A space will be inserted here\cite{Larry,Curly,Moe}.
+o Allow, but discourage, line breaks within the group of citations (after
+  dashes, and after punctuation). 
 
-o With package option [superscript] (or [super] for short), display citation
-  numbers as superscripts (unless they have optional notes, causing them to
-  be treated as described above).  Superscripted citations follow these
-  additional rules:
+o Adjust spacing before citation.
 
-- Superscript citations use THE SAME INPUT FORMAT as ordinary citations; this
-  style will ignore spaces before the citation, and move trailing punctuation
-  before the superscript citation.  For example, "information \cite{source};"
-  ignores the space before \cite and puts the semicolon before the number, just
-  as if you had typed "information;$^{12}$".  You may switch off movement with
-  the [nomove] package option (only relevant with [superscript]).
+o All breaks can be forbidden with the [nobreak] package option.
 
-- The punctuation characters that will migrate before the superscript are
-  listed in the macro \CiteMoveChars, which you can redefine.  The default is
-  .,;:.   Perhaps ! and ? should too, but they weren't listed in the APS style
-  manual I looked at, and I agree with that rule to prevent too much visual
-  separation.  Quotes were listed, but they should never have to migrate
-  because both on-line and superscript versions put quotes before the citation.
-  This gives one difficulty --- punctuation following quotes won't migrate
-  inside the quotation: e.g., "``Transition State Theory''\cite{Eyring}." gives
-  "``Transition State Theory''.$^8$", but you may want the period inside the
-  quotes, thus: ``Transition State Theory.''$^8$.
-
-- Doubling of periods (.., ?., !.) is checked for and suppressed. The spacing
-  after the citation is set according to the final punctuation mark moved.
-  There is a problem with double periods after a capitalized abbreviation
-  or directly after \@ : Both of "N.A.S.A. \cite{space}." and "et al.\@
-  \cite{many}." will give doubled periods.  These can be fixed as follows:
-  "N.A.S.A\@. \cite{space}." and "et al.\ \cite{many}.". The NASA example 
-  gives the wrong spacing when there is no citation.  Sorry.  Use \  after
-  abbreviations like et al. to get the right spacing within a sentence whether
-  or not a citation follows.
-
-- Remember, these rules regarding punctuation only apply when the [superscript]
-  option was given (or overcite.sty used) and the [nomove] option was NOT
-  given.
+o With package option [superscript] (or [super] for short), display citations
+  as superscripts (unless they have optional notes, causing them to be printed 
+  on-line with brackets).  Superscripted citations use THE SAME INPUT FORMAT 
+  as ordinary citations; this style will ignore spaces before the \cite command
+  and move trailing punctuation before the superscript citation. Doubling of 
+  periods (.., ?., !.) is checked for and suppressed. 
 
 o Define \citen to get just the numbers without the brackets or superscript
-  and extra formatting.  Aliases are \citenum and \citeonline for easy
-  conversion to other citation packages.
+  and extra formatting.  Aliases are \citenum and \citeonline.
 
-o `Citation...undefined' warnings are only given once per undefined citation
-  tag.  In the text, missing numbers are represented with a bold `?' at the
-  first occurrence, and with a normal `?' thenceforth.  The package option
-  [verbose] restores the usual repeated warnings.
-
-o Make \nocite, \cite, and \citen all ignore spaces in the input tags.
-
-Although each \cite command sorts its numbers, better compression into
-ranges can usually be achieved by carefully selecting the order of the
-\bibitem entries or the order of initial citations when using BibTeX.
-Having the entries pre-sorted will also save processing time, especially
-for long lists of numbers.
-
-Customization:
-~~~~~~~~~~~~~~
-There are several options for \usepackage{cite}, some already mentioned.
+There are several package options for \usepackage{cite}.
 
  [superscript] use superscrpts for cites without optional notes
  [super]       alias for [superscript] (like natbib)
- [verbose]     causes warnings for undefined cites to be repeated each time
- [ref]         uses the format "[Ref.~12, optional note]" (useful with 
-               the superscript option)
- [nospace]     eliminates the spaces after commas in the number list.
+ [nospace]     eliminates the spaces after commas in the number list
  [space]       uses a full inter-word space after the commas
- [nosort]      prevents sorting of the numbers (default is to sort, and a
+ [nobreak]     eliminate all line-breaks
+ [nosort]      prevents sorting of the numbers (default is to sort, and the...
  [sort]        option is provided for completeness).
  [nomove]      prevents moving the superscript cite after punctuation.
  [move]        is the default
@@ -417,55 +608,15 @@ There are several options for \usepackage{cite}, some already mentioned.
  [adjust]      is the default
  [nocompress]  inhibit compression of consecutive numbers into ranges
  [compress]    is the default
- [biblabel]    define the bibliography label as a superscript
+ [ref]         uses the format "[Ref.~12, given note]" (useful with [super])
+ [biblabel]    define the bibliography label to match \cite
 
-There are several commands that you may redefine to change the formatting
-of citation lists:
+If your citations are not numeric, then you should probably not use 
+cite.sty, but if you must, then at least use the [nosort,nocompress] 
+options.
 
-command       function                   default
-----------    -----------------------    ----------------------------
-\citeform     reformats each number      nothing
-\citepunct    printed between numbers    comma + penalty + thin space
-\citeleft     left delimiter of list     [
-\citeright    right delimeter of list    ]
-\citemid      printed before note        comma + space
-\citedash     used in a compressed range endash + penalty
-\CiteMoveChars  charcters that move      .,:;
-\OverciteFont   font selection command for superscripts
+See more detailed instructions in cite.pdf (cite.ltx). 
 
-The left/mid/right commands don't affect the formatting of superscript
-citations.  You may use \renewcommand to change any of these.  Remember,
-these commands are extensions made by this package; they are not regular
-LaTeX.  Some examples of changes:
-
-1: \renewcommand\citeform[1]{\romannumeral 0#1}} % roman numerals i,vi
-2: \renewcommand\citeform[1]{(#1)} % parenthesized numbers (1)-(5),(9)
-3: \renewcommand\citeform{\thechapter.}  % by chapter: ^{2.18-2.21}
-4: \renewcommand\citepunct{,} % no space and no breaks at commas
-5: \renewcommand\citemid{; }  % semicolon before optional note
-6: \renewcommand\citeleft{(}  % parentheses around list with note
-   \renewcommand\citeright{)} % parentheses around list with note
-
-The appearance of the whole citation list is governed by \@cite, (for full-
-sized cites) and \@citess (for superscripts).  For more extensive changes 
-to the formatting, redefine these.  For example, to get brackets around the 
-list of superscript numbers you can do:
-
-   \def\@citess#1{\textsuperscript{[#1]}}
-
-after \makeatletter.
-
-Related Note:  The superscript option does not affect the numbering format
-of the bibliography; the "[12]" style is still the default.  To get
-superscripts in the bibliography (at any time) you can define
-
-   \renewcommand\@biblabel[1]{\textsuperscript{#1}}
-
-Aw, OK, for your convenience, there is the [biblabel] package option that
-just performs this definition (sort of).
-
-\@extra@b@citeb is a hook for other style files to further specify
-citations; for example, to number by chapter (see chapterbib.sty).
 
 % Version 1991: Ignore spaces after commas in the parameter list. Move most of
 % \citen into \@cmpresscites for speed. Give the proper \spacefactor afterwards.
@@ -493,6 +644,20 @@ citations; for example, to number by chapter (see chapterbib.sty).
 % 4.0: Combine overcite with cite: [superscript] option.  Also add [nocompress]
 %      option and \CiteMoveChars; multibib hooks.
 % 4.01 \bf -> \bfseries
+% 4.02 Bury undouble action in a separate macro to avoid extra \fi error.
+% 5.0  Hyperref and backref compatability! Penalty parameters and [nobreak]. 
+%      Letter prefix and suffix sorting! Stop suppressing multiple warnings.
+% 5.1  Fix a missing "b@" (disappearing named cites), fix nosort
+% 5.2  More robust treatment of non-numbers
+% 5.3  Handle sort/compress of compound citation numbers (number by chapter)
+%      such as 3.18 or 5-3.  Note that these compounds cannot have prefix or
+%      suffix letters (not enough bits in the maximum TeX number).
+% 5.4  Only ignore spaces at begin and end of tag (LaTeX ignores at begin)
+% 5.5  Improve handling of \frenchspacing. Option rearrangements.
+%
+% TODO: other sorting, like dictionary or roman numeral
+% TODO: create special "final punct" that could be ", and " and likewise
+%       a "single punct" that could be " and " 
 %
 % Send problem reports to asnd@triumf.ca
 


### PR DESCRIPTION
The `cite.sty` file included in the ISMIR template is quite old and does not properly support `hyperref`. This PR updates it to the latest version. This partially helps #13, but does not close it.