### PR TITLE
Negative parskip looks weird

### DIFF
--- a/2020/latex/ismir.sty
+++ b/2020/latex/ismir.sty
@@ -96,7 +96,7 @@
 \setlength{\evensidemargin}{-6mm}
 
 \setlength\normallineskip{1\p@}
-\setlength\parskip{0\p@ \@minus 4\p@}
+%\setlength\parskip{0\p@ \@minus 4\p@}
 %\def\baselinestretch{0.98}
 
 \def\normalsize{\@setsize\normalsize{12.2pt}\txpt\@xpt}


### PR DESCRIPTION
In the 2020 latex template, I had the issue that the margin between paragraphs sometimes seems to be less than the space between two lines within a paragraph, which looks really weird.

To illustrate the issue I created this [minimal example](https://gist.github.com/fzalkow/4feab2e58fcde7311888949e6c5de0de).

After compilation, the file looks [like this [pdf]](https://github.com/ismir/paper_templates/files/4347745/Lorem_ISMIR2020template1.pdf). Note the weird margins, e.g., between lines 44/45, 53/54, 66/67, etc. After commenting out the `parskip` command in the sty file, the pdf looks [like this [pdf]](https://github.com/ismir/paper_templates/files/4347753/ISMIR2020template2.pdf), which is much nicer IMO.
