### PR TITLE
Fix figure width

### DIFF
--- a/2020/latex/ISMIR2020template.tex
+++ b/2020/latex/ISMIR2020template.tex
@@ -198,7 +198,7 @@ Figures and tables may extend across both columns to a maximum width of 17.2cm.
 
 \begin{figure}
  \centerline{\framebox{
- \includegraphics[width=\columnwidth]{figure.png}}}
+ \includegraphics[width=0.9\columnwidth]{figure.png}}}
  \caption{Figure captions should be placed below the figure.}
  \label{fig:example}
 \end{figure}


### PR DESCRIPTION
The column width in the word template excludes the width of lineno.
![image](https://user-images.githubusercontent.com/2303500/80517463-14911500-89c0-11ea-81fe-f09e0b41875e.png)
But in the LaTeX template, 100% column width causes the figure overlapping with the second column, which makes the figure in the example pdf very weird.
![image](https://user-images.githubusercontent.com/2303500/80517575-4013ff80-89c0-11ea-8cf4-ae2cb73c158b.png)
This patch slightly modified the width of the figure to avoid this problem.