### PR TITLE
Add `review` option to `tismir` package, which adds line numbers

### DIFF
--- a/TISMIR/latex/TISMIRtemplate.tex
+++ b/TISMIR/latex/TISMIRtemplate.tex
@@ -10,6 +10,8 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \usepackage[utf8]{inputenc}
+% To remove the line numbers for the camera-ready version of your paper, remove
+% the `review` option from the tismir package
 \usepackage[review]{tismir}
 \usepackage{amsmath}
 \usepackage{hyperref}
@@ -194,6 +196,14 @@ as in Eqn.~(\ref{eq:eq}).
 \begin{align}\label{eq:eq}
 E = mc^2
 \end{align}
+
+\section{Line numbers}
+Line numbers are printed in the margins to facilitate the
+review process. To remove line numbers for the camera-ready
+version of your paper, remove the \verb=review= option from the
+\verb=tismir= package in the preamble:
+\verb=\usepackage[review]{tismir}= $\rightarrow$
+\verb=\usepackage{tismir}=.
 
 \section{Reproducibility (if applicable)}
 

--- a/TISMIR/latex/TISMIRtemplate.tex
+++ b/TISMIR/latex/TISMIRtemplate.tex
@@ -10,7 +10,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \usepackage[utf8]{inputenc}
-\usepackage{tismir}
+\usepackage[review]{tismir}
 \usepackage{amsmath}
 \usepackage{hyperref}
 \usepackage{url}

--- a/TISMIR/latex/tismir.sty
+++ b/TISMIR/latex/tismir.sty
@@ -272,3 +272,8 @@
 
 \flushbottom
 \sloppy
+
+\usepackage[switch]{lineno}
+\DeclareOption{review}{\linenumbers}
+\DeclareOption*{\PackageWarning{tismir}{Unknown ‘\CurrentOption’}}
+\ProcessOptions\relax


### PR DESCRIPTION
With this PR the `tismir` package obtains a `review` option, which adds line numbers for easier reviewing:

```
\usepackage[review]{tismir}
```

To eliminate the line numbers for the camera ready version of the paper, the `review` option can be simply removed:


```
\usepackage{tismir}
```

Fixes https://github.com/ismir/paper_templates/issues/34