### PR TITLE
Add (commented out) `\clearpage` command for +n sections

### DIFF
--- a/2024/latex/ISMIR2024_template.tex
+++ b/2024/latex/ISMIR2024_template.tex
@@ -221,6 +221,10 @@ for a single reference, or \cite{JNMR10Someone:01,Book20Person:01,Chapter09Perso
 
 \textcolor{red}{As submission is double blind, refer to your own published work in the third person. That is, use ``In the previous work of \cite{ISMIR17Author:01},'' not ``In our previous work \cite{ISMIR17Author:01}.'' If you cite your other papers that are not widely available (e.g., a journal paper under review), use anonymous author names in the citation, e.g., an author of the form ``A. Anonymous.''}
 
+% Uncomment the \clearpage command to start a new page for the Acknowledgements,
+% Ethics Statement, and References.
+% \clearpage
+
 \section{Acknowledgments}
 
 \textbf{Do not include in your submission, only in your camera ready version}. This section can be used to refer to any


### PR DESCRIPTION
When the paper you're writing approaches the 6 page limit, the sections that don't count toward the limit ( Acknlowledgments, Ethics Statement and References) will remain on page 6 as long as there is space, possibly pushing tables and figures past the 6 page limit. This makes it hard to estimate how much of the 6 page budget (if any) remains.

The `\clearpage` command pushes the Acknlowledgments, Ethics Statement and References to a new page, freeing up space for any figure/table that is beyond the 6 page limit.

Note: the `\newpage` command that I (and perhaps others) first tried to use for this purpose, only starts a new column, not a new page.